### PR TITLE
build fix

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -11,7 +11,9 @@ jobs:
       with:
         submodules: recursive
     - name: install tools
-      run: gem install --user-install cbor-diag cddl
+      run: |
+        gem install --user-install cbor-diag
+        gem install --user-install cddl -v 0.10.3
     - name: set up PATH
       run: echo "$(gem env gempath | cut -d':' -f1)/bin" >> $GITHUB_PATH
     - name: assemble and test


### PR DESCRIPTION
use `cddl(1)` at v0.10.3 since latest (v0.10.5) breaks on the flags test.