### PR TITLE
Created workaround for corim breaking change

### DIFF
--- a/concise-evidence.cddl
+++ b/concise-evidence.cddl
@@ -9,7 +9,9 @@ $evidence-id-type-choice /= tagged-uuid-type
 ; additional evidence identifier types may be added here
 
 ev-triples-map = non-empty< {
-  ? &(ce.evidence-triples: 0) => [ + reference-triple-record ]
+  ;? &(ce.evidence-triples: 0) => [ + reference-triple-record ]
+  ; temporary workaround to non-speccompliant reference-triple-record
+  ? &(ce.evidence-triples: 0) => [ + ce.evidence-triple-record ]
   ? &(ce.identity-triples: 1) => [ + identity-triple-record ]
   ? &(ce.dependency-triples: 2) => [ + domain-dependency-triple-record ]
   ? &(ce.domain-membership-triples: 3) => [ + domain-membership-triple-record ]
@@ -28,3 +30,9 @@ ev-coswid-evidence-map = {
     &(ce.coswid-evidence: 1) => evidence-entry
   ? &(ce.authorized-by: 2) => [ + $crypto-key-type-choice ] ; see comid schema
 }
+
+; temporary workaround
+ce.evidence-triple-record = [
+  environment-map
+  [ + measurement-map ]
+]

--- a/examples/ce-indirect.diag
+++ b/examples/ce-indirect.diag
@@ -9,18 +9,20 @@
               / comid.vendor / 1 : "xyzinc.example"
           }
         },
-        / measurement-map / {
-          / mval / 1 : {
-            / spdm-indirect / 12 : / extends measurement-values-map / {
-              / index / 0 : [ 1, 2, 3, 4, 5 ]
+        [
+          / measurement-map / {
+            / mval / 1 : {
+              / spdm-indirect / 12 : / extends measurement-values-map / {
+                / index / 0 : [ 1, 2, 3, 4, 5 ]
+              },
+              / digests / 2 : [ [ 1, h'FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0'] ],
+              / raw-value / 4 : 560(h'0123456789')
             },
-            / digests / 2 : [ [ 1, h'FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0'] ],
-            / raw-value / 4 : 560(h'0123456789')
-          },
-          / authorized-by / 2 : [
-            / tagged-pkix-base64-key-type / 554("base64_key_X")
-          ]
-        }
+            / authorized-by / 2 : [
+              / tagged-pkix-base64-key-type / 554("base64_key_X")
+            ]
+          }
+        ]
       ]
     ]
   },

--- a/examples/spdm-indirect.diag
+++ b/examples/spdm-indirect.diag
@@ -11,18 +11,20 @@
                   / comid.vendor / 1 : "xyzinc.example"
               }
             },
-            / measurement-map / {
-              / comid.mval / 1 : {
-                / digests / 2 : [ [ 1, h'FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0'] ],
-                / raw-value / 4 : 560(h'0123456789'),
-                / comid.spdm-indirect / 12 : {
-                  / spdm.index / 0 : [ 1, 2, 3, 4, 5 ]
-                }
-              },
-              / comid.authorized-by / 2 : [
-                / tagged-pkix-base64-key-type / 554("base64_key_X")
-              ]
-            }
+            [
+              / measurement-map / {
+                / comid.mval / 1 : {
+                  / digests / 2 : [ [ 1, h'FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0'] ],
+                  / raw-value / 4 : 560(h'0123456789'),
+                  / comid.spdm-indirect / 12 : {
+                    / spdm.index / 0 : [ 1, 2, 3, 4, 5 ]
+                  }
+                },
+                / comid.authorized-by / 2 : [
+                  / tagged-pkix-base64-key-type / 554("base64_key_X")
+                ]
+              }
+            ]
           ]
         ]
       }


### PR DESCRIPTION
Corim in ietf created a breaking change to reference-triple-record that removed multiplicity of measurement-map. This workaround replaces the brackets.