### PR TITLE
Revert temp ev triple

### DIFF
--- a/concise-evidence.cddl
+++ b/concise-evidence.cddl
@@ -9,9 +9,7 @@ $evidence-id-type-choice /= tagged-uuid-type
 ; additional evidence identifier types may be added here
 
 ev-triples-map = non-empty< {
-  ;? &(ce.evidence-triples: 0) => [ + reference-triple-record ]
-  ; temporary workaround to non-speccompliant reference-triple-record
-  ? &(ce.evidence-triples: 0) => [ + ce.evidence-triple-record ]
+  ? &(ce.evidence-triples: 0) => [ + reference-triple-record ]
   ? &(ce.identity-triples: 1) => [ + identity-triple-record ]
   ? &(ce.dependency-triples: 2) => [ + domain-dependency-triple-record ]
   ? &(ce.domain-membership-triples: 3) => [ + domain-membership-triple-record ]
@@ -30,9 +28,3 @@ ev-coswid-evidence-map = {
     &(ce.coswid-evidence: 1) => evidence-entry
   ? &(ce.authorized-by: 2) => [ + $crypto-key-type-choice ] ; see comid schema
 }
-
-; temporary workaround
-ce.evidence-triple-record = [
-  environment-map
-  [ + measurement-map ]
-]

--- a/examples/comid-aaa.diag
+++ b/examples/comid-aaa.diag
@@ -1,0 +1,93 @@
+/ concise-mid-tag / {
+  / comid.tag-identity / 1 : {
+    / comid.tag-id / 0 : h'1EACD596F4A34FB699BFAEB58E0A4E47'
+  },
+  / comid.entities / 2 : [ {
+    / comid.entity-name / 0 : "FPGA Designs-R-Us",
+    / comid.reg-id / 1 : 32("https://fpgadesignsrus.example"),
+    / comid.role / 2 : [ 0 ] / tag-creator /
+  } ],
+  / comid.linked-tags / 3 : [ 
+      / linked-tag-map / {
+          / comid.linked-tag-id / 0 : h'97F5A7071C6F438F877A4A020780EBE9',
+          / comid.tag-rel / 1 : / comid.supplements / 0
+      }
+  ],
+  / comid.triples / 4 : {
+    / comid.reference-triples / 0 : [
+      [
+        / environment-map / {
+          / ** Layer 3 device state ** /
+          / comid.class / 0 : {
+            / comid.class-id / 0 :
+              / tagged-oid-type / 111(h'0607517B010F0401'), / 2.1.123.1.15.4.1 /
+            / comid.vendor / 1 : "fpgadesignsrus.example",
+            / comid.layer / 3 : 2
+          }
+        },
+        [
+          / measurement-map / {
+            / comid.mval / 1 : {
+              / raw-value-group /
+              / comid.raw-value / 4 : 560(h'0000000000000000'),
+              / comid.raw-value-mask / 5 : h'FFFFFFFF00000000'
+            },
+            / comid.authorized-by / 2 : [
+              / tagged-pkix-base64-key-type / 554("base64_fpgadesignsrus_key_y")
+            ]
+          }
+        ]
+      ],
+      [
+        / environment-map / {
+          / ** Layer 2 design (IO descriptor) hash ** /
+          / comid.class / 0 : {
+            / comid.class-id / 0 :
+              / tagged-oid-type / 111(h'0607517B010F0402'), / 2.1.123.1.15.4.2 /
+            / comid.vendor / 1 : "fpgadesignsrus.example",
+            / comid.layer / 3 : 2
+          }
+        },
+        [
+          / measurement-map / {
+            / comid.mval / 1 : {
+              / comid.digests / 2 : [
+                [
+                / hash-alg-id / 7, / SHA384 /
+                / hash-value / h'3FE18ECA4053879E017EF5EB7A3E5157659C5F9BB15B7D09959B8B8647822A4CC21C3AA6721CEF87F5BFA53495DB0833'
+                ]
+              ]
+            },
+            / comid.authorized-by / 2 : [
+              / tagged-pkix-base64-key-type / 554("base64_fpgadesignsrus_key_y")
+            ]
+          }
+        ]
+      ]
+    ],
+    / comid.endorsed-triples / 1 : [
+      [
+        / environment-map / {
+          / ** Design is valid (example assertion) ** /
+          / comid.class / 0 : {
+            / comid.class-id / 0 :
+              / tagged-oid-type / 111(h'0607517B010F046302'), / 2.1.123.1.15.4.99.2 /
+            / comid.vendor / 1 : "fpgadesignsrus.example"
+          }
+        },
+        [
+          / measurement-map / {
+            / comid.mval / 1 : {
+              / raw-value-group /
+                / comid.raw-value / 4 : 560(h'0000000000000000'),
+                / comid.raw-value-mask / 5 : h'FFFFFFFF00000000'
+            },
+            / comid.authorized-by / 2 : [
+              / tagged-pkix-base64-key-type / 554("base64_fpgadesignsrus_key_z")
+            ]
+          }
+        ]
+      ]
+    ]
+  }
+}

--- a/examples/comid-design.diag
+++ b/examples/comid-design.diag
@@ -78,16 +78,18 @@
             / comid.layer / 3 : 2
           }
         },
-        / measurement-map / {
-          / comid.mval / 1 : {
-            / raw-value-group /
-            / comid.raw-value / 4 : 560(h'0000000000000000'),
-            / comid.raw-value-mask / 5 : h'FFFFFFFF00000000'
-          },
-          / comid.authorized-by / 2 : [
-            / tagged-pkix-base64-key-type / 554("base64_fpgadesignsrus_key_y")
-          ]
-        }
+        [
+          / measurement-map / {
+            / comid.mval / 1 : {
+              / raw-value-group /
+              / comid.raw-value / 4 : 560(h'0000000000000000'),
+              / comid.raw-value-mask / 5 : h'FFFFFFFF00000000'
+            },
+            / comid.authorized-by / 2 : [
+              / tagged-pkix-base64-key-type / 554("base64_fpgadesignsrus_key_y")
+            ]
+          }
+        ]
       ],
       [
         / environment-map / {
@@ -99,19 +101,21 @@
             / comid.layer / 3 : 2
           }
         },
-        / measurement-map / {
-          / comid.mval / 1 : {
-            / comid.digests / 2 : [
-              [
-              / hash-alg-id / 7, / SHA384 /
-              / hash-value / h'3FE18ECA4053879E017EF5EB7A3E5157659C5F9BB15B7D09959B8B8647822A4CC21C3AA6721CEF87F5BFA53495DB0833'
+        [
+          / measurement-map / {
+            / comid.mval / 1 : {
+              / comid.digests / 2 : [
+                [
+                / hash-alg-id / 7, / SHA384 /
+                / hash-value / h'3FE18ECA4053879E017EF5EB7A3E5157659C5F9BB15B7D09959B8B8647822A4CC21C3AA6721CEF87F5BFA53495DB0833'
+                ]
               ]
+            },
+            / comid.authorized-by / 2 : [
+              / tagged-pkix-base64-key-type / 554("base64_fpgadesignsrus_key_y")
             ]
-          },
-          / comid.authorized-by / 2 : [
-            / tagged-pkix-base64-key-type / 554("base64_fpgadesignsrus_key_y")
-          ]
-        }
+          }
+        ]
       ],
       [
         / environment-map / {
@@ -123,19 +127,21 @@
             / comid.layer / 3 : 2
           }
         },
-        / measurement-map / {
-          / comid.mval / 1 : {
-            / comid.digests / 2 : [
-              [
-                / hash-alg-id / 7, / SHA384 /
-                / hash-value / h'20FF681A0882E29B481953888936209CB53DF9C5AAEC606A2C24A0FB138595124B8E3F24A12771BC3854CC68B40361AD'
+        [
+          / measurement-map / {
+            / comid.mval / 1 : {
+              / comid.digests / 2 : [
+                [
+                  / hash-alg-id / 7, / SHA384 /
+                  / hash-value / h'20FF681A0882E29B481953888936209CB53DF9C5AAEC606A2C24A0FB138595124B8E3F24A12771BC3854CC68B40361AD'
+                ]
               ]
+            },
+            / comid.authorized-by / 2 : [
+              / tagged-pkix-base64-key-type / 554("base64_fpgadesignsrus_key_y")
             ]
-          },
-          / comid.authorized-by / 2 : [
-            / tagged-pkix-base64-key-type / 554("base64_fpgadesignsrus_key_y")
-          ]
-        }
+          }
+        ]
       ],
       [
         / environment-map / {
@@ -146,38 +152,42 @@
             / comid.vendor / 1 : "fpgadesignsrus.example"
             }
         },
-        / measurement-map / {
-          / comid.mval / 1 : {
-            / raw-value-group /
-              / comid.raw-value / 4 : 560(h'000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'),
-              / comid.raw-value-mask / 5 : h'466224343D681802C1506BBED7D7F00B969BADDD6346E4F2E7CE146692996F22A45814DE81D248F583B65F817B5FCEAB'
-            },
-          / comid.authorized-by / 2 : [
-            / tagged-pkix-base64-key-type / 554("base64_fpgadesignsrus_key_z")
-          ]
-        }
+        [
+          / measurement-map / {
+            / comid.mval / 1 : {
+              / raw-value-group /
+                / comid.raw-value / 4 : 560(h'000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'),
+                / comid.raw-value-mask / 5 : h'466224343D681802C1506BBED7D7F00B969BADDD6346E4F2E7CE146692996F22A45814DE81D248F583B65F817B5FCEAB'
+              },
+            / comid.authorized-by / 2 : [
+              / tagged-pkix-base64-key-type / 554("base64_fpgadesignsrus_key_z")
+            ]
+          }
+        ]
       ]
     ],
     / comid.endorsed-triples / 1 : [
       [
-          / environment-map / {
+        / environment-map / {
           / ** Design is valid (example assertion) ** /
-            / comid.class / 0 : {
-              / comid.class-id / 0 :
-                / tagged-oid-type / 111(h'0607517B010F046302'), / 2.1.123.1.15.4.99.2 /
-              / comid.vendor / 1 : "fpgadesignsrus.example"
-            }
-        }, 
-        / measurement-map / {
-          / comid.mval / 1 : {
-            / raw-value-group /
-              / comid.raw-value / 4 : 560(h'0000000000000000'),
-              / comid.raw-value-mask / 5 : h'FFFFFFFF00000000'
-          },
-          / comid.authorized-by / 2 : [
-            / tagged-pkix-base64-key-type / 554("base64_fpgadesignsrus_key_z")
-          ]
-        }
+          / comid.class / 0 : {
+            / comid.class-id / 0 :
+              / tagged-oid-type / 111(h'0607517B010F046302'), / 2.1.123.1.15.4.99.2 /
+            / comid.vendor / 1 : "fpgadesignsrus.example"
+          }
+        },
+        [
+          / measurement-map / {
+            / comid.mval / 1 : {
+              / raw-value-group /
+                / comid.raw-value / 4 : 560(h'0000000000000000'),
+                / comid.raw-value-mask / 5 : h'FFFFFFFF00000000'
+            },
+            / comid.authorized-by / 2 : [
+              / tagged-pkix-base64-key-type / 554("base64_fpgadesignsrus_key_z")
+            ]
+          }
+        ]
       ]
     ]
   }

--- a/examples/comid-domain-memb.diag
+++ b/examples/comid-domain-memb.diag
@@ -54,20 +54,22 @@
               / comid.index / 4 : 0
             }
           },
-          / measurement-map / {
-            / comid.mval / 1 : {
-              / comid.svn / 1 : 552(1),
-              / comid.digests / 2 : [
-                [
-                  / hash-alg-id / 7, / SHA384 /
-                  / hash-value / h'15E77D6F133252F1DB7044901313884F2977D2109B33C79F33E079BFC78865255C0FB733C240FDDA544B8215D7B8F815'
+          [
+            / measurement-map / {
+              / comid.mval / 1 : {
+                / comid.svn / 1 : 552(1),
+                / comid.digests / 2 : [
+                  [
+                    / hash-alg-id / 7, / SHA384 /
+                    / hash-value / h'15E77D6F133252F1DB7044901313884F2977D2109B33C79F33E079BFC78865255C0FB733C240FDDA544B8215D7B8F815'
+                  ]
                 ]
+              },
+              / comid.authorized-by / 2 : [
+                / tagged-pkix-base64-key-type / 554("base64_intel_key_x")
               ]
-            },
-            / comid.authorized-by / 2 : [
-              / tagged-pkix-base64-key-type / 554("base64_intel_key_x")
-            ]
-          }
+            }
+          ]
         ],
         [
           / environment-map / {
@@ -79,20 +81,22 @@
               / comid.index / 4 : 0
             }
           },
-          / measurement-map / {
-            / comid.mval / 1 : {
-              / comid.svn / 1 : 552(1),
-              / comid.digests / 2 : [
-                [
-                  / hash-alg-id / 7, / SHA384 /
-                  / hash-value / h'3D90B6BF003DA2D94EA5463F97FB3C53DDC51CFBA1E3E38EEF7AF071A67986595D22729131DF9FE80F5451EEF154F85E'
+          [
+            / measurement-map / {
+              / comid.mval / 1 : {
+                / comid.svn / 1 : 552(1),
+                / comid.digests / 2 : [
+                  [
+                    / hash-alg-id / 7, / SHA384 /
+                    / hash-value / h'3D90B6BF003DA2D94EA5463F97FB3C53DDC51CFBA1E3E38EEF7AF071A67986595D22729131DF9FE80F5451EEF154F85E'
+                  ]
                 ]
+              },
+              / comid.authorized-by / 2 : [
+                / tagged-pkix-base64-key-type / 554("base64_intel_key_x")
               ]
-            },
-            / comid.authorized-by / 2 : [
-              / tagged-pkix-base64-key-type / 554("base64_intel_key_x")
-            ]
-          }
+            }
+          ]
         ]
       ],
       / comid.endorsed-triples / 1 : [
@@ -105,16 +109,18 @@
               / comid.vendor / 1 : "fwmfginc.example"
            }
           },
-          / measurement-map / {
-            / comid.mval / 1 : {
-                / raw-value-group /
-                / comid.raw-value / 4 : 560(h'0000000000000000'),
-                / comid.raw-value-mask / 5 : h'FFFFFFFF00000000'
-            },    
-            / comid.authorized-by / 2 : [
-                / tagged-pkix-base64-key-type / 554("base64_intel_key_x")
-            ]
-          } 
+          [
+            / measurement-map / {
+              / comid.mval / 1 : {
+                  / raw-value-group /
+                  / comid.raw-value / 4 : 560(h'0000000000000000'),
+                  / comid.raw-value-mask / 5 : h'FFFFFFFF00000000'
+              },    
+              / comid.authorized-by / 2 : [
+                  / tagged-pkix-base64-key-type / 554("base64_intel_key_x")
+              ]
+            }
+          ]
         ]
       ]
     }

--- a/examples/comid-flags.diag
+++ b/examples/comid-flags.diag
@@ -28,24 +28,26 @@
             / vendor / 1 : "fwmfginc.example"
           }
         },
-        / measurement-map / {
-          / mval / 1 : {
-            / flags / 3 : { 
-                / configured / 0 : true,
-                / secure / 1 : true,
-                / not-recovery / 2 : true,
-                / debug / 3 : false,
-                / replay-protected / 4 : true,
-                / integrity-protected / 5 : true,
-                / runtime-meas / 6 : true,
-                / immutable / 7 : true,
-                / tcb / 8 : true
-              } 
-          },
-          / comid.authorized-by / 2 : [
-            / tagged-pkix-base64-key-type / 554("base64_key_X")
-          ]
-        }
+        [
+          / measurement-map / {
+            / mval / 1 : {
+              / flags / 3 : { 
+                  / configured / 0 : true,
+                  / secure / 1 : true,
+                  / not-recovery / 2 : true,
+                  / debug / 3 : false,
+                  / replay-protected / 4 : true,
+                  / integrity-protected / 5 : true,
+                  / runtime-meas / 6 : true,
+                  / immutable / 7 : true,
+                  / tcb / 8 : true
+                } 
+            },
+            / comid.authorized-by / 2 : [
+              / tagged-pkix-base64-key-type / 554("base64_key_X")
+            ]
+          }
+        ]
       ]
     ]
   }

--- a/examples/comid-spdmi.diag
+++ b/examples/comid-spdmi.diag
@@ -28,16 +28,18 @@
             / vendor / 1 : "fwmfginc.example"
           }
         },
-        / measurement-map / {
-          / mval / 1 : {
-            / spdm-indirect / 12 : {
-              / index / 0 : [ 1, 2, 3, 4, 5 ]
-            }
-          },
-          / authorized-by / 2 : [
-            / tagged-pkix-base64-key-type / 554("base64_key_X")
-          ]
-        }
+        [
+          / measurement-map / {
+            / mval / 1 : {
+              / spdm-indirect / 12 : {
+                / index / 0 : [ 1, 2, 3, 4, 5 ]
+              }
+            },
+            / authorized-by / 2 : [
+              / tagged-pkix-base64-key-type / 554("base64_key_X")
+            ]
+          }
+        ]
       ]
     ]
   }


### PR DESCRIPTION
Accommodated corim changes that placed array brackets around measurement-map in reference and endorsed triples.