### PR TITLE
Nms/export coev.cddl

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -22,4 +22,4 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         files: |
-          ./*-autogen.cddl
+          ./exports/coev.cddl ./*-autogen.cddl

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,3 @@ check-imports:
 $(eval $(call cddl_exp_template,coev,$(CE_DEPS),$(EXPORTS_DIR),$(IMPORT_FRAGS)))
 
 clean: ; rm -f $(CLEANFILES); $(MAKE) -C $(IMPORTS_DIR) clean
-
-exce: ce-autogen.cddl
-	@echo -n "copying ce.cddl to exports"
-	# @cp $(CE_DIR)/ce-autogen.cddl exports/ce.cddl
-	$(eval $(call cddl_exports_template, exports/ce, $(CE_DEPS)))

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ check:: check-eat check-eat-examples
 check:: check-comidx check-comidx-examples
 check:: check-spdm check-spdm-examples
 check:: check-ce check-ce-examples
-check:: exp-ce
+check:: exp-coev
 
 include $(CE_DIR)ce-frags.mk
 CE_DEPS := $(addprefix $(CE_DIR), $(CE_FRAGS))
@@ -70,8 +70,8 @@ $(IMPORT_DEPS): check-imports
 check-imports:
 	$(MAKE) -C $(IMPORTS_DIR)
 
-# Make ce.cddl export file
-$(eval $(call cddl_exp_template,ce,$(CE_DEPS)))
+# Make coev.cddl export file - used by cddl-releases
+$(eval $(call cddl_exp_template,coev,$(CE_DEPS),$(EXPORTS_DIR),$(IMPORT_FRAGS)))
 
 clean: ; rm -f $(CLEANFILES); $(MAKE) -C $(IMPORTS_DIR) clean
 

--- a/exports/coev.cddl
+++ b/exports/coev.cddl
@@ -1,3 +1,5 @@
+; This cddl file depends on these cddl files: corim-autogen.cddl
+
 spdm-toc = spdm-toc-map / tagged-spdm-toc
 
 tagged-spdm-toc = #6.570(spdm-toc-map)

--- a/funcs.mk
+++ b/funcs.mk
@@ -31,19 +31,23 @@ CLEANFILES += $(3:.diag=.pretty)
 
 endef # cddl_check_template
 
+# $(1) - export label
+# $(2) - cddl fragments 
+# $(3) - export directory
+# $(4) - import dependencies
 define cddl_exp_template
 
-exp-$(1): $(EXPORTS_DIR)$(1).cddl
+exp-$(1): $(3)$(1).cddl
 	echo ">>> Creating exportable cddl file" ;
 
 .PHONY: exp-$(1)
 
-$(EXPORTS_DIR)$(1).cddl: $(2)
-	
+$(3)$(1).cddl: $(2)
+	echo -e "; This cddl file depends on these cddl files: "$(4)"\n" > $$@
 	@for f in $$^ ; do \
 		( grep -v '^;' $$$$f ; echo ) ; \
-	done > $$@
+	done >> $$@
 
-CLEANFILES += $(EXPORTS_DIR)$(1).cddl
+CLEANFILES += $(3)$(1).cddl
 
 endef # cddl_exp_template

--- a/imports/Makefile
+++ b/imports/Makefile
@@ -13,7 +13,7 @@ corim_rel_dl := draft-ietf-rats-corim/releases/download/
 corim_tag := cddl-8c267cd
 corim_url := $(join $(github), $(join $(corim_rel_dl), $(corim_tag)))
 
-corim-autogen.cddl: ; $(curl) -LO $(corim_url)/$@
+corim-autogen.cddl: ; $(curl) -LO $(corim_url)/$@ ; grep -v '^@\.start\.@' $@ > $@.tmp ; mv $@.tmp $@
 
 CLEANFILES += corim-autogen.cddl
 


### PR DESCRIPTION
Added concise evidennce cddl file to cddl-releases that doesn't include start=xxx and doesn't include dependent cddl files. Strips @.start.@ from imported cddl files. 